### PR TITLE
Change the input to have `display: none`

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -64,7 +64,7 @@ $checkradio-top-offset: 0rem !default
 .is-checkradio[type="checkbox"]
   outline: 0
   user-select: none
-  display: inline-block
+  display: none
   position: absolute
   opacity: 0
 


### PR DESCRIPTION
When the input is positioned absolutely (like it is), checking it causes the page to jump in certain situations. If the input is not displayed (which it doesn't need to be because of this extension), there is no jumping of the page.

In my specific project, I had a scrollable div in the center of my page that had dynamically added boxes containing bulma-checkradios in it. Once the div is scrolled a bit and I check a box, the entire page shifts upward a large amount. Setting the input to display:none or to positions: relative fixes this.