### PR TITLE
Fix deprecation warning at math.divison

### DIFF
--- a/src/sass/index.sass
+++ b/src/sass/index.sass
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $checkbox-radius: $radius !default
 $checkbox-border: .1rem solid $grey-lighter !default
 $checkbox-block-background: $white-ter !default
@@ -7,8 +9,8 @@ $checkradio-top-offset: 0rem !default
 
 =checkbox-size($size)
   $newSize: $size * 1.5
-  $height: $newSize / 2.5
-  $width: $newSize / 4
+  $height: math.div($newSize, 2.5)
+  $width: math.div($newSize, 4)
 
   + label
     font-size: $size
@@ -22,7 +24,7 @@ $checkradio-top-offset: 0rem !default
     &:after
       width: $width
       height: $height
-      top: ( ( $newSize / 2 ) - ( $height / 2 ) ) * 0.9
+      top: ( ( math.div($newSize, 2) ) - ( math.div($height, 2) ) ) * 0.9
       left: $height
 
   &.is-block


### PR DESCRIPTION
Fix this warning.

`DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.`

see.
https://sass-lang.com/documentation/breaking-changes/slash-div